### PR TITLE
chore(ci): Lint CIをmainブランチだけで実行

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,11 @@ name: Lint
 
 on:
   push:
+    branches:
+      - 'main'
   pull_request:
     branches:
-      - '**'
+      - 'main'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Lint CIをmainブランチだけで実行するようにします。
